### PR TITLE
Add Recaptcha toggle env parameter

### DIFF
--- a/src/Form/Frontend/AbstractFrontendFormType.php
+++ b/src/Form/Frontend/AbstractFrontendFormType.php
@@ -3,6 +3,7 @@
 namespace Superrb\KunstmaanAddonsBundle\Form\Frontend;
 
 use Superrb\GoogleRecaptchaBundle\Validator\Constraint\GoogleRecaptcha;
+use Superrb\KunstmaanAddonsBundle\Service\RecaptchaFlagService;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -16,9 +17,15 @@ class AbstractFrontendFormType extends AbstractType
      */
     protected $urlGenerator;
 
-    public function __construct(UrlGeneratorInterface $urlGenerator)
+    /**
+     * @var bool
+     */
+    protected $recaptchaEnabled;
+
+    public function __construct(UrlGeneratorInterface $urlGenerator, RecaptchaFlagService $recaptchaFlagService)
     {
-        $this->urlGenerator = $urlGenerator;
+        $this->urlGenerator     = $urlGenerator;
+        $this->recaptchaEnabled = $recaptchaFlagService->isRecaptchaEnabled();
     }
 
     /**
@@ -28,7 +35,7 @@ class AbstractFrontendFormType extends AbstractType
     {
         parent::buildForm($builder, $options);
 
-        if (!isset($options['recaptcha']) || true === $options['recaptcha']) {
+        if ($this->recaptchaEnabled && (!isset($options['recaptcha']) || true === $options['recaptcha'])) {
             $builder->add('recaptcha', HiddenType::class, [
                 'mapped'      => false,
                 'constraints' => [

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,5 +1,6 @@
 parameters:
   env(TURBOLINKS_ENABLED): false
+  recaptcha.enabled: "%env(bool:RECAPTCHA_ENABLED)%"
   turbolinks.enabled: "%env(bool:TURBOLINKS_ENABLED)%"
 
 services:
@@ -62,3 +63,14 @@ services:
       $logger: '@Psr\Log\LoggerInterface'
       $emailFrom: "%enquiryfrom%"
       $emailBcc: "%enquirybcc%"
+
+  Superrb\KunstmaanAddonsBundle\Form\Frontend\AbstractFrontendFormType:
+    public: true
+    arguments:
+      $urlGenerator: '@Symfony\Component\Routing\Generator\UrlGeneratorInterface'
+      $recaptchaFlagService: '@Superrb\KunstmaanAddonsBundle\Service\RecaptchaFlagService'
+
+  Superrb\KunstmaanAddonsBundle\Service\RecaptchaFlagService:
+    public: true
+    arguments:
+      $recaptchaEnabled: '%recaptcha.enabled%'

--- a/src/Service/RecaptchaFlagService.php
+++ b/src/Service/RecaptchaFlagService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Superrb\KunstmaanAddonsBundle\Service;
+
+class RecaptchaFlagService
+{
+    /**
+     * @var bool
+     */
+    protected $recaptchaEnabled;
+
+    public function __construct(bool $recaptchaEnabled)
+    {
+        $this->recaptchaEnabled = $recaptchaEnabled;
+    }
+
+    public function isRecaptchaEnabled(): bool
+    {
+        return $this->recaptchaEnabled;
+    }
+}


### PR DESCRIPTION
This will be a major version bump, since it will require a change to any forms which override the constructor for `AbstractFrontendFormType` to inject the new `RecaptchaFlagService`. In practice, overriding the constructor isn't that common, and I think it's only really me who's done it on a regular basis.

It was done with a tiny service class as injecting the parameter directly into `AbstractFrontendFormType` means that any classes extending it would need to have the new parameter injected directly in `services.yaml`. Using a service class means a single definition can be added in the bundle itself, and it will be autowired automatically in the app.

Fixes #1 